### PR TITLE
README: put badges after the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+# netjail
+
 [![Build](https://github.com/stealthrocket/netjail/actions/workflows/test.yml/badge.svg)](https://github.com/stealthrocket/netjail/actions/workflows/test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/stealthrocket/netjail)](https://goreportcard.com/report/github.com/stealthrocket/netjail)
 [![Go Reference](https://pkg.go.dev/badge/github.com/stealthrocket/netjail.svg)](https://pkg.go.dev/github.com/stealthrocket/netjail)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-# netjail
 Go library providing network access controls for dial functions and http transports
 
 ## Motivation


### PR DESCRIPTION
This is the convention we adopted on the dispatch-* repositories, so I'm updating this README as well to stay consistent.